### PR TITLE
GUAC 1.5.0 is now released and not in dev

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -7,9 +7,9 @@ ENV CATALINA_HOME=/opt/tomcat \
     POSTGRES_DB=guacamole_db \
     POSTGREJDBC_VER=42.5.4 \
     S6OVERLAY_VER=3.1.3.0 \
-    GUAC_DOWN_PATH=https://dist.apache.org/repos/dist/dev/guacamole \
+    GUAC_DOWN_PATH=https://dist.apache.org/repos/dist/release/guacamole \
     GUAC_VER=1.5.0 \
-    GUAC_VER_PATH=1.5.0-RC1 \
+    GUAC_VER_PATH=1.5.0 \
     PG_MAJOR=14 \
     TOMCAT_VER=9.0.71
 

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -12,9 +12,9 @@ ENV GUACAMOLE_HOME=/app/guacamole \
   POSTGRES_DB=guacamole_db \
   S6OVERLAY_VER=3.1.3.0 \
   POSTGREJDBC_VER=42.5.4 \
-  GUAC_DOWN_PATH=https://dist.apache.org/repos/dist/dev/guacamole \
+  GUAC_DOWN_PATH=https://dist.apache.org/repos/dist/release/guacamole \
   GUAC_VER=1.5.0 \
-  GUAC_VER_PATH=1.5.0-RC1 \
+  GUAC_VER_PATH=1.5.0 \
   PG_MAJOR=13
 
 RUN apt-get update && apt-get upgrade -y && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -12,9 +12,9 @@ ENV GUACAMOLE_HOME=/app/guacamole \
   POSTGRES_DB=guacamole_db \
   S6OVERLAY_VER=3.1.3.0 \
   POSTGREJDBC_VER=42.5.4 \
-  GUAC_DOWN_PATH=https://dist.apache.org/repos/dist/dev/guacamole \
+  GUAC_DOWN_PATH=https://dist.apache.org/repos/dist/release/guacamole \
   GUAC_VER=1.5.0 \
-  GUAC_VER_PATH=1.5.0-RC1 \
+  GUAC_VER_PATH=1.5.0 \
   PG_MAJOR=13
 
 RUN set -xe && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \

--- a/Dockerfile.ubuntu.pg14
+++ b/Dockerfile.ubuntu.pg14
@@ -12,9 +12,9 @@ ENV GUACAMOLE_HOME=/app/guacamole \
   POSTGRES_DB=guacamole_db \
   S6OVERLAY_VER=3.1.3.0 \
   POSTGREJDBC_VER=42.5.4 \
-  GUAC_DOWN_PATH=https://dist.apache.org/repos/dist/dev/guacamole \
+  GUAC_DOWN_PATH=https://dist.apache.org/repos/dist/release/guacamole \
   GUAC_VER=1.5.0 \
-  GUAC_VER_PATH=1.5.0-RC1 \
+  GUAC_VER_PATH=1.5.0 \
   PG_MAJOR=14
 
 RUN apt-get update && \


### PR DESCRIPTION
Amending the GUAC environment variables to reflect updated repo URLs